### PR TITLE
Visual Studio 2019 plugin templates extension updates

### DIFF
--- a/TemplatesVSIX/SDL Custom Batch Task/pluginpackage.manifest.xml
+++ b/TemplatesVSIX/SDL Custom Batch Task/pluginpackage.manifest.xml
@@ -4,5 +4,5 @@
   <Version>1.0</Version>
   <Description>Plugin description</Description>
   <Author></Author>
-  <RequiredProduct name="SDLTradosStudio" minversion="15.0" />
+  <RequiredProduct name="SDLTradosStudio" minversion="15.0" maxversion="16.0"/>
 </PluginPackage>

--- a/TemplatesVSIX/SDL Terminology Provider/pluginpackage.manifest.xml
+++ b/TemplatesVSIX/SDL Terminology Provider/pluginpackage.manifest.xml
@@ -4,5 +4,5 @@
   <Version>1.0</Version>
   <Description>Plugin description</Description>
   <Author></Author>
-  <RequiredProduct name="SDLTradosStudio" minversion="15.0" />
+  <RequiredProduct name="SDLTradosStudio" minversion="15.0" maxversion="16.0"/>
 </PluginPackage>

--- a/TemplatesVSIX/SDL Trados Studio/pluginpackage.manifest.xml
+++ b/TemplatesVSIX/SDL Trados Studio/pluginpackage.manifest.xml
@@ -4,5 +4,5 @@
   <Version>1.0</Version>
   <Description>Plugin description</Description>
   <Author></Author>
-  <RequiredProduct name="SDLTradosStudio" minversion="15.0" />
+  <RequiredProduct name="SDLTradosStudio" minversion="15.0" maxversion="16.0"/>
 </PluginPackage>

--- a/TemplatesVSIX/SDL Translation Provider/pluginpackage.manifest.xml
+++ b/TemplatesVSIX/SDL Translation Provider/pluginpackage.manifest.xml
@@ -4,5 +4,5 @@
   <Version>1.0</Version>
   <Description>Plugin description</Description>
   <Author></Author>
-  <RequiredProduct name="SDLTradosStudio" minversion="15.0" />
+  <RequiredProduct name="SDLTradosStudio" minversion="15.0" maxversion="16.0"/>
 </PluginPackage>

--- a/TemplatesVSIX/TemplatesVSIX.csproj
+++ b/TemplatesVSIX/TemplatesVSIX.csproj
@@ -209,7 +209,10 @@
     <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>packages\Microsoft.VisualStudio.TextManager.Interop.8.0.8.0.50727\lib\Microsoft.VisualStudio.TextManager.Interop.8.0.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.Threading, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="Microsoft.VisualStudio.Threading, Version=16.4.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>packages\Microsoft.VisualStudio.Threading.15.0.240\lib\net45\Microsoft.VisualStudio.Threading.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.Utilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.VisualStudio.Utilities.15.0.26201\lib\net45\Microsoft.VisualStudio.Utilities.dll</HintPath>
     </Reference>

--- a/TemplatesVSIX/source.extension.vsixmanifest
+++ b/TemplatesVSIX/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="55EB68BF-6752-4EF6-B251-111469A1372B" Version="1.3" Language="en-US" Publisher="SDL" />
+    <Identity Id="55EB68BF-6752-4EF6-B251-111469A1372B" Version="1.4" Language="en-US" Publisher="SDL" />
     <DisplayName>Trados Studio templates for Visual Studio</DisplayName>
     <Description xml:space="preserve">Visual Studio templates for SDL Trados Studio 2019.
 

--- a/TemplatesVSIX/source.extension.vsixmanifest
+++ b/TemplatesVSIX/source.extension.vsixmanifest
@@ -17,7 +17,6 @@ Copyright © 2019 SDL. All rights reserved.</Description>
   </Installation>
   <Dependencies>
     <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    <Dependency d:Source="Installed" Id="Microsoft.VisualStudio.MPF.16.0" DisplayName="Visual Studio MPF 16.0" Version="[16.0,17.0)" />
     <Dependency d:Source="Installed" d:ProjectName="SDL Custom Batch Task" Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" Version="[14.0,15.0)" />
   </Dependencies>
   <Prerequisites>


### PR DESCRIPTION
Add maxversion="16.0" on each corresponding plugin project, so will restrict the installation of 2019 plugins on Studio 2021.
Remove dependency which restrict the installation on Visual Studio 2017.
Update TemplatesVSIX .NetFramework to 4.7